### PR TITLE
ensemble_hierarchy

### DIFF
--- a/examples/demo_ensemble_hierarchy.py
+++ b/examples/demo_ensemble_hierarchy.py
@@ -1,0 +1,75 @@
+""" demo of using the ensemble hierarchy objects """
+
+from __future__ import division
+
+from firedrake import *
+from firedrake_mlmc import *
+
+import numpy as np
+
+
+# Create mesh hierarchy
+mesh = UnitSquareMesh(5, 5)
+L = 2
+refinements_per_level = 2
+mesh_h = MeshHierarchy(mesh, L, refinements_per_level=refinements_per_level)
+
+# Create function space / function hierarchies
+V_h = tuple([FunctionSpace(m, 'DG', 1) for m in mesh_h])
+u_h = []
+for i in range(len(V_h)):
+    u_h.append(Function(V_h[i]))
+
+# make an ensemble hierarchy
+e_h = EnsembleHierarchy(V_h)
+
+# check the refinement factor
+print 'refinement factor of FSH = ', e_h.M
+
+# Append several random states to the ensemble hierarchy on the bottom level
+coarse = Function(V_h[0])
+fine = Function(V_h[1])
+for i in range(10):
+    x = np.random.normal(0, 1, 1)[0]
+    coarse.assign(sin(x))
+    fine.assign(sin(x))
+    S = State(coarse, fine)
+    e_h.AppendToEnsemble(S)
+
+# Next append several random states to the ensemble hierarchy on the finest level
+coarse = Function(V_h[1])
+fine = Function(V_h[2])
+for i in range(10):
+    x = np.random.normal(0, 1, 1)[0]
+    coarse.assign(sin(x))
+    fine.assign(sin(x))
+    S = State(coarse, fine)
+    e_h.AppendToEnsemble(S)
+
+# print the ensemble hierarchy lengths
+print e_h.nl
+
+# print the ensemble hierarchy resolutions
+print 'refinement of M =', e_h, ', ensemble hierarchy resolutions = ', e_h.dxl
+
+# Update statistics
+
+e_h.UpdateStatistics()
+
+# print the data of the multilevel expectation
+print 'Multilevel Exp cell basis coeffs: ', e_h.MultilevelExpectation.dat.data
+
+# should be the same as just the first level mean
+print 'First level mean cell basis coeffs: ', e_h.Mean[0].dat.data
+
+# with both variances set to 0
+print 'With variance in cell basis coeffs on first level: ', e_h.Variance[0].dat.data
+
+print 'but none on the second: ', e_h.Variance[1].dat.data
+
+# now clear the ensemble
+e_h.UpdateStatistics(clear_ensemble=True)
+
+print 'Even though the ensemble hierarchy has been cleared, ', e_h._hierarchy
+
+print 'the online size of the ensembles used to compute the statistics still remain: ', e_h.nl

--- a/firedrake_mlmc/__init__.py
+++ b/firedrake_mlmc/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 from firedrake_mlmc.state import *  # noqa
 from firedrake_mlmc.min_dx import *  # noqa
+from firedrake_mlmc.ensemble_hierarchy import *  # noqa

--- a/firedrake_mlmc/ensemble_hierarchy.py
+++ b/firedrake_mlmc/ensemble_hierarchy.py
@@ -1,0 +1,310 @@
+""" Generates an ensemble hierarchy object """
+
+from __future__ import absolute_import
+
+from firedrake_mlmc.min_dx import *
+
+from firedrake import *  # noqa
+from firedrake.mg.utils import *  # noqa
+
+
+class EnsembleHierarchy(object):
+
+    """ This class creates and builds a hierarchy of ensembles as well as containing properties of them, such as statistics.
+
+        :param function_spaces: Tuple of function spaces corresponding to each level of a :class:`MeshHierarchy`.
+        :type function_spaces: Tuple
+
+        :param state_type: Type of states, either :class:`Function` or :class:`Constant`
+        :type state_type: :class:`Function` or :class:`Constant`
+
+    """
+
+    def __init__(self, function_spaces, state_type=Function):
+
+        # check that the state type is one of the required
+        if state_type != Function and state_type != Constant:
+            raise TypeError('state_type argument is not Constant or Function')
+
+        # this is the hierarchy of function spaces
+        self._fs_hierarchy = function_spaces
+
+        if not isinstance(self._fs_hierarchy, (list, tuple)):
+            raise TypeError('hierarchy of function spaces input is not a tuple or a list')
+
+        # check that all levels of FS correspond to domains in the same hierarchy
+        hierarchy = get_level(self._fs_hierarchy[0].mesh())[0]
+        if hierarchy is None:
+            raise ValueError('function spaces arent on meshes part of a hierarchy or the same hierarchy')
+        else:
+            self._mesh_hierarchy = hierarchy
+
+        for fs in self._fs_hierarchy:
+            assert get_level(fs.mesh())[0] == hierarchy
+
+        # This is the actual hierarchy of ensembles
+        self._hierarchy = []
+
+        # Length of the hierarchy
+        self.L = 0
+
+        # Refinement factor
+        self.M = self._mesh_hierarchy.refinements_per_level * 2
+
+        # the min cell edge length in each level of ensemble hierarchy
+        self.dxl = []
+
+        # type of ensemble hierarchy input (default :class:`Function`)
+        self._type = state_type
+
+        # sample statistics
+        if self._type == Function:
+            self.MultilevelExpectation = Function(self._fs_hierarchy[-1])
+            self.MultilevelExpectation.rename('MLMC Estimator')
+
+        if self._type == Constant:
+            self.MultilevelExpectation = Constant(0, domain=self._fs_hierarchy[-1].mesh())
+
+        self.Mean = []  # : A list of the sample mean Functions of each of the different levels
+        self.Variance = []  # : A list of the sample variance Functions of each of the different levels
+
+        # running totals for sample statistics
+        self.nl = []
+        self.__sum_of_sq = []
+        self.__sum = []
+
+        super(EnsembleHierarchy, self).__init__()
+
+    def __UpdateFunctionSpace(self, s, lvlc):
+
+        """ Updates the :class:`FunctionSpace` of the appended State.state :class:`Function` to the
+            finest level :class:`FunctionSpace` in the hierarchy
+
+            :param S: The state
+            :type S: :class:`State`.state
+
+        """
+
+        # Prolong both the state to this and put into a tuple
+        u_1 = Function(self._fs_hierarchy[-1])
+        u_2 = Function(self._fs_hierarchy[-1])
+        if lvlc == len(self._fs_hierarchy) - 2:  # need this check to avoid error in prolonging to same level (finest)
+            prolong(s[0], u_1)
+            u_2.assign(s[1])
+        else:
+            prolong(s[0], u_1)
+            prolong(s[1], u_2)
+        Tuple_to_append = tuple([u_1, u_2])
+
+        return Tuple_to_append
+
+    def __UpdateDomain(self, s):
+
+        """ Updates the :class:`Domain` of the appended State.state :class:`Constant` to the
+            finest level :class:`Domain` in the hierarchy
+
+            :param S: The state
+            :type S: :class:`State`.state
+
+        """
+
+        # Prolong both the state to this and put into a tuple
+        u_1 = Constant(s[0], domain=self._fs_hierarchy[-1].mesh())
+        u_2 = Constant(s[1], domain=self._fs_hierarchy[-1].mesh())
+        Tuple_to_append = tuple([u_1, u_2])
+
+        return Tuple_to_append
+
+    def AppendToEnsemble(self, S):
+
+        """ Appends a state to a certain level of the ensemble hierarchy.
+
+                :param S: The state
+                :type S: :attr:`State'
+
+        """
+
+        if not isinstance(S.state, tuple):
+
+            raise TypeError('input to append isnt a tuple')
+
+        if get_level(S.state[0].domain())[1] is None:
+
+            raise TypeError('state members arent part of a hierarchy')
+
+        if not isinstance(S.state[0], self._type):
+
+            raise TypeError('The state does not consist of correct types')
+
+        if not isinstance(S.state[1], self._type):
+
+            raise TypeError('The state does not consist of correct types')
+
+        # Recover level of state (the coarser level)
+        Level_to_append_to = S.levels[0]
+
+        if Level_to_append_to < self.L:  # if there already exists that level in ensemble hierarchy
+
+            # prolong the function space of state inputs to finest level of hierarchy
+            # (:class:`Function` only!)
+            if self._type == Function:
+                T = self.__UpdateFunctionSpace(S.state, Level_to_append_to)
+
+            if self._type == Constant:
+                T = self.__UpdateDomain(S.state)
+
+            # append state to required level
+            self._hierarchy[Level_to_append_to].append(T)
+
+            # update ensemble sizes
+            self.nl[Level_to_append_to] += 1
+
+            # update sums and squares
+            if Level_to_append_to == 0:
+                self.__sum[Level_to_append_to] = self.__sum[Level_to_append_to] + T[1]
+                self.__sum_of_sq[Level_to_append_to] = (self.__sum_of_sq[Level_to_append_to] +
+                                                        (T[1] ** 2))
+
+            else:
+                self.__sum[Level_to_append_to] = self.__sum[Level_to_append_to] + (T[1] - T[0])
+                self.__sum_of_sq[Level_to_append_to] = (self.__sum_of_sq[Level_to_append_to] +
+                                                        ((T[1] - T[0]) ** 2))
+
+        if Level_to_append_to >= self.L:  # if the level doesn't exist in ensemble hierarchy
+
+            # make sure previous level exists, otherwise make an empty ensemble on empty levels
+            if Level_to_append_to - 1 > self.L:
+                skipped_levels = Level_to_append_to - self.L
+
+                for i in range(skipped_levels + 1):
+                    self._hierarchy.append([])
+                    self.nl.append(0)
+                    self.dxl.append(0)
+
+                    if self._type == Function:
+                        self.Mean.append(Function(self._fs_hierarchy[-1]))
+                        self.Mean[i].rename('Sample Mean')
+                        self.Variance.append(Function(self._fs_hierarchy[-1]))
+                        self.Variance[i].rename('Sample Variance')
+                        self.__sum.append(Function(self._fs_hierarchy[-1]))
+                        self.__sum_of_sq.append(Function(self._fs_hierarchy[-1]))
+
+                    if self._type == Constant:
+                        self.Mean.append(Constant(0,
+                                                  domain=self._fs_hierarchy[-1].mesh()))
+                        self.Variance.append(Constant(0,
+                                                      domain=self._fs_hierarchy[-1].mesh()))
+                        self.__sum.append(Constant(0,
+                                                   domain=self._fs_hierarchy[-1].mesh()))
+                        self.__sum_of_sq.append(Constant(0,
+                                                         domain=self._fs_hierarchy[-1].mesh()))
+
+            else:
+
+                self._hierarchy.append([])
+                self.nl.append(0)
+                self.dxl.append(0)
+
+                if self._type == Function:
+                    self.Mean.append(Function(self._fs_hierarchy[-1]))
+                    self.Mean[Level_to_append_to].rename('Sample Mean')
+                    self.Variance.append(Function(self._fs_hierarchy[-1]))
+                    self.Variance[Level_to_append_to].rename('Sample Variance')
+                    self.__sum.append(Function(self._fs_hierarchy[-1]))
+                    self.__sum_of_sq.append(Function(self._fs_hierarchy[-1]))
+
+                if self._type == Constant:
+                    self.Mean.append(Constant(0, domain=self._fs_hierarchy[-1].mesh()))
+                    self.Variance.append(Constant(0, domain=self._fs_hierarchy[-1].mesh()))
+                    self.__sum.append(Constant(0, domain=self._fs_hierarchy[-1].mesh()))
+                    self.__sum_of_sq.append(Constant(0, domain=self._fs_hierarchy[-1].mesh()))
+
+            # update length of ensemble hierarchy
+            self.L = np.max([self.L, Level_to_append_to + 1])
+
+            # prolong the function space of state inputs to finest level of hierarchy
+            # (:class:`Function` only!)
+            if self._type == Function:
+                T = self.__UpdateFunctionSpace(S.state, Level_to_append_to)
+
+            if self._type == Constant:
+                T = self.__UpdateDomain(S.state)
+
+            # append state to required level
+            self._hierarchy[Level_to_append_to].append(T)
+
+            # update ensemble sizes
+            self.nl[Level_to_append_to] += 1
+
+            # update sums and squares
+            if Level_to_append_to == 0:
+                self.__sum[Level_to_append_to] = self.__sum[Level_to_append_to] + T[1]
+                self.__sum_of_sq[Level_to_append_to] = (self.__sum_of_sq[Level_to_append_to] +
+                                                        (T[1] ** 2))
+
+            else:
+                self.__sum[Level_to_append_to] = self.__sum[Level_to_append_to] + (T[1] - T[0])
+                self.__sum_of_sq[Level_to_append_to] = (self.__sum_of_sq[Level_to_append_to] +
+                                                        ((T[1] - T[0]) ** 2))
+
+            # compute min cell edge length for finer level of state
+            self.dxl[Level_to_append_to] = MinDx(S.state[1].domain())
+
+    def ClearEnsemble(self):
+        """ Clears the ensemble hierarchy
+
+        """
+
+        for i in range(self.L):
+            self._hierarchy[i] = []
+
+    def UpdateStatistics(self, clear_ensemble=False):
+        """ Updates statistics of ensemble hierarchy and has the option to clear the stored ensemble
+            hierarchy afterwards
+
+            :param clear_ensemble: Whether or not to clear the ensemble after updating stats (Fals)
+            :type clear_ensemble: boolean
+
+        """
+
+        # update statistics on each level
+        for i in range(self.L):
+            self.Mean[i].assign(self.__sum[i] / self.nl[i])
+            self.Variance[i].assign((self.__sum_of_sq[i] / self.nl[i]) - ((self.__sum[i] / self.nl[i]) ** 2))
+
+        # update running multilevel monte carlo average
+        if self._type == Function:
+            mlmc_sum = Function(self._fs_hierarchy[-1])
+
+        if self._type == Constant:
+            mlmc_sum = Constant(0, domain=self._fs_hierarchy[-1].mesh())
+
+        for i in range(self.L):
+            mlmc_sum = mlmc_sum + self.Mean[i]
+
+        self.MultilevelExpectation.assign(mlmc_sum)
+
+        if clear_ensemble is True:
+
+            # clear ensemble hierarchy
+            self.ClearEnsemble()
+
+    """ Iterative and Indexing functions """
+
+    def __len__(self):
+        """ Return the length of the ensemble hierarchy """
+        return self.L
+
+    def __iter__(self):
+        """ Iterate over the ensembles in the hierarchy (from
+        coarse to fine). """
+        for en in self._hierarchy:
+            yield en
+
+    def __getitem__(self, idx):
+        """ Return an ensemble in the hierarchy
+
+            :arg idx: The index of the ensemble to return
+
+        """
+        return self._hierarchy[idx]

--- a/tests/test_ensemble_hierarchy.py
+++ b/tests/test_ensemble_hierarchy.py
@@ -1,0 +1,348 @@
+""" tests the ensemble hierarchy object """
+
+from firedrake_mlmc import *
+
+import pytest
+
+
+def test_ensemble_hierarchy_same_fs_check():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+    u_h_1 = Function(V_h[0])
+    u_h_2 = Function(V_h[1])
+
+    EH = EnsembleHierarchy(V_h)
+
+    S = State(u_h_1, u_h_2)
+    EH.AppendToEnsemble(S)
+
+    assert EH[0][0][0].function_space() == EH[0][0][1].function_space()
+
+
+def test_ensemble_hierarchy_constants_1():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+    u_h_1 = Constant(0, domain=MH[0])
+    u_h_2 = Constant(0, domain=MH[1])
+
+    S = State(u_h_1, u_h_2)
+
+    EH = EnsembleHierarchy(V_h)
+
+    a = 0
+    b = 1
+
+    try:
+        EH.AppendToEnsemble(S)
+
+    except TypeError:
+        a = 1
+        b = 0
+
+    assert a > b
+
+
+def test_ensemble_hierarchy_constants_2():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+    u_h_1 = Constant(0, domain=MH[0])
+    u_h_2 = Constant(0, domain=MH[1])
+
+    S = State(u_h_1, u_h_2)
+
+    EH = EnsembleHierarchy(V_h, state_type=Constant)
+
+    a = 0
+    b = 1
+
+    try:
+        EH.AppendToEnsemble(S)
+
+    except TypeError:
+        a = 1
+        b = 0
+
+    assert a < b
+
+
+def test_ensemble_hierarchy_attr():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+    u_h_1 = Function(V_h[0])
+    u_h_2 = Function(V_h[1])
+
+    EH = EnsembleHierarchy(V_h)
+
+    assert EH.M == 2
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    assert len(EH.nl) == 1
+
+    assert EH.nl[0] == 10
+
+    assert len(EH.dxl) == 1
+
+    assert np.abs(EH.dxl[0] - np.sqrt((0.05 ** 2))) < 1e-8
+
+    assert EH.L == 1
+
+
+def test_ensemble_hierarchy_skip_levels():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[2])
+    u_h_2 = Function(V_h[3])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    assert EH.L == 3
+
+    assert len(EH.dxl) == 3
+
+    assert len(EH.nl) == 3
+
+    assert EH.nl[2] == 10
+
+    assert EH.nl[0] == 0 and EH.nl[1] == 0
+
+
+def test_ensemble_hierarchy_refinement():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[0])
+    u_h_2 = Function(V_h[1])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    u_h_1 = Function(V_h[1])
+    u_h_2 = Function(V_h[2])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    assert EH.L == 2
+
+    assert EH.L == len(EH)
+
+    assert np.sum(np.abs((EH.dxl / EH.dxl[0]) - (2 ** - np.linspace(0, 1, 2)))) < 1e-8
+
+
+def test_clear_ensemble():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[0])
+    u_h_2 = Function(V_h[1])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    u_h_1 = Function(V_h[1])
+    u_h_2 = Function(V_h[2])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    EH.UpdateStatistics(clear_ensemble=True)
+
+    assert len(EH) == 2
+
+    assert EH[0] == []
+
+    assert EH[1] == []
+
+    assert EH.nl == [10, 10]
+
+
+def test_keep_ensemble():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[0])
+    u_h_2 = Function(V_h[1])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    u_h_1 = Function(V_h[1])
+    u_h_2 = Function(V_h[2])
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    EH.UpdateStatistics()
+
+    assert len(EH) == 2
+
+    assert len(EH[0]) == 10
+
+    assert len(EH[1]) == 10
+
+    assert EH.nl == [10, 10]
+
+
+def test_mean():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[0]).assign(1)
+    u_h_2 = Function(V_h[1]).assign(2)
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    u_h_1 = Function(V_h[1]).assign(2)
+    u_h_2 = Function(V_h[2]).assign(3)
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    EH.UpdateStatistics()
+
+    assert np.all(EH.MultilevelExpectation.dat.data == 3) == 1
+
+    assert np.all(EH.Mean[0].dat.data == 2) == 1
+
+    assert np.all(EH.Mean[1].dat.data == 1) == 1
+
+
+def test_variance():
+
+    M = UnitSquareMesh(10, 10)
+    L = 3
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[0]).assign(1)
+    u_h_2 = Function(V_h[1]).assign(2)
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    u_h_1 = Function(V_h[1]).assign(2)
+    u_h_2 = Function(V_h[2]).assign(3)
+
+    for i in range(10):
+
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    EH.UpdateStatistics()
+
+    assert np.all(EH.Variance[0].dat.data == 0) == 1
+
+    assert np.all(EH.Variance[1].dat.data == 0) == 1
+
+
+def test_mean_variance_compute():
+
+    M = UnitSquareMesh(10, 10)
+    L = 1
+    MH = MeshHierarchy(M, L)
+
+    V_h = [FunctionSpace(m, 'DG', 1) for m in MH]
+
+    EH = EnsembleHierarchy(V_h)
+
+    u_h_1 = Function(V_h[0])
+    u_h_2 = Function(V_h[1])
+
+    for i in range(2):
+
+        u_h_1.assign(i)
+        u_h_2.assign(i)
+        S = State(u_h_1, u_h_2)
+        EH.AppendToEnsemble(S)
+
+    exact_mean = 0.5
+    exact_variance = 0.5 - 0.25
+
+    EH.UpdateStatistics()
+
+    assert np.all(EH.Variance[0].dat.data == exact_variance) == 1
+
+    assert np.all(EH.Mean[0].dat.data == exact_mean) == 1
+
+    assert np.all(EH.MultilevelExpectation.dat.data == exact_mean) == 1
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
**Added the `EnsembleHierarchy` object**, along with suitable tests and a demo. This is the main object within `firedrake-mlmc`, where many states from different levels can be stored to calculate multilevel Monte Carlo estimates of statistics from the system, and properties of these states can also be kept. The `EnsembleHierarchy` object can be cleared to allow for storage advantages.
