### PR TITLE
update_ensemble_members

### DIFF
--- a/examples/demo_ensemble_hierarchy_updating.py
+++ b/examples/demo_ensemble_hierarchy_updating.py
@@ -1,0 +1,88 @@
+""" demo of using the ensemble hierarchy object and updating ensemble members """
+
+from __future__ import division
+
+from firedrake import *
+from firedrake_mlmc import *
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+
+# Create mesh hierarchy
+mesh = UnitIntervalMesh(5)
+L = 2
+refinements_per_level = 2
+mesh_h = MeshHierarchy(mesh, L, refinements_per_level=refinements_per_level)
+
+# Create function space / function hierarchies
+V_h = tuple([FunctionSpace(m, 'DG', 0) for m in mesh_h])
+u_h = []
+for i in range(len(V_h)):
+    u_h.append(Function(V_h[i]))
+
+# Make an ensemble hierarchy
+e_h = EnsembleHierarchy(V_h)
+
+# Append several random states to the ensemble hierarchy on the bottom level
+coarse = Function(V_h[0])
+fine = Function(V_h[1])
+for i in range(10):
+    # Find the coordinates
+    xc = SpatialCoordinate(mesh_h[0])
+    xf = SpatialCoordinate(mesh_h[1])
+
+    # Random shift
+    x_shift = np.random.normal(0, 0.1, 1)[0]
+    coarse.interpolate(sin(2 * pi * (xc[0] + x_shift)))
+    fine.interpolate(sin(2 * pi * (xf[0] + x_shift)))
+    S = State(coarse, fine)
+    e_h.AppendToEnsemble(S)
+
+# Next append several random states to the ensemble hierarchy on the finest level
+coarse = Function(V_h[1])
+fine = Function(V_h[2])
+for i in range(10):
+    # Find the coordinates
+    xc = SpatialCoordinate(mesh_h[1])
+    xf = SpatialCoordinate(mesh_h[2])
+
+    # Random shift
+    x_shift = np.random.normal(0, 0.1, 1)[0]
+    coarse.interpolate(sin(2 * pi * (xc[0] + x_shift)))
+    fine.interpolate(sin(2 * pi * (xf[0] + x_shift)))
+    S = State(coarse, fine)
+    e_h.AppendToEnsemble(S)
+
+# Update statistics
+e_h.UpdateStatistics()
+
+# Plot the mlmc mean
+plot(e_h.MultilevelExpectation)
+plt.axis([0, 1, -3, 3])
+
+# Update ensemble hierarchy with a random shift in the y axis
+for i in range(10):
+    x = np.random.normal(0.25, 0.1, 1)
+
+    # Update state from state hierarchy
+    e_h._state_hierarchy[0][i].state[0].dat.data[:] += x
+    e_h._state_hierarchy[0][i].state[1].dat.data[:] += x
+    e_h.UpdateEnsembleMember(e_h._state_hierarchy[0][i])
+
+for i in range(10):
+    x = np.random.normal(0.25, 0.1, 1)
+
+    # Update state from state hierarchy
+    e_h._state_hierarchy[1][i].state[0].dat.data[:] += x
+    e_h._state_hierarchy[1][i].state[1].dat.data[:] += x
+    e_h.UpdateEnsembleMember(e_h._state_hierarchy[1][i])
+
+# Update statistics
+e_h.UpdateStatistics()
+
+# Plot the mlmc mean
+plot(e_h.MultilevelExpectation)
+plt.axis([0, 1, -3, 3])
+plt.show()

--- a/firedrake_mlmc/state.py
+++ b/firedrake_mlmc/state.py
@@ -54,4 +54,8 @@ class State(object):
         if self.levels[1] - 1 != self.levels[0]:
             raise ValueError('levels of inputs are not consecutive')
 
+        # set index and identifiers - identifiers are used for checking purposes
+        self.index = None
+        self.identifier = None
+
         super(State, self).__init__()

--- a/tests/test_ensemble_hierarchy.py
+++ b/tests/test_ensemble_hierarchy.py
@@ -464,14 +464,10 @@ def test_updating_ensemble_members():
     u_h_1 = Function(V_h[0]).assign(1)
     u_h_2 = Function(V_h[1]).assign(2)
 
-    ens1 = []
-    ens2 = []
-
     for i in range(10):
 
         S = State(u_h_1, u_h_2)
         EH.AppendToEnsemble(S)
-        ens1.append(S)
 
     u_h_1 = Function(V_h[1]).assign(2)
     u_h_2 = Function(V_h[2]).assign(3)
@@ -480,7 +476,6 @@ def test_updating_ensemble_members():
 
         S = State(u_h_1, u_h_2)
         EH.AppendToEnsemble(S)
-        ens2.append(S)
 
     EH.UpdateStatistics()
     Mean = np.copy(EH.MultilevelExpectation.dat.data[:])
@@ -488,8 +483,8 @@ def test_updating_ensemble_members():
     # change the states
     for i in range(10):
 
-        ens2[i].state[1].assign(4)
-        EH.UpdateEnsembleMember(ens2[i])
+        EH._state_hierarchy[1][i].state[1].assign(4)
+        EH.UpdateEnsembleMember(EH._state_hierarchy[1][i])
 
     EH.UpdateStatistics()
     NewMean = EH.MultilevelExpectation.dat.data[:]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -120,6 +120,56 @@ def test_state_levels_4():
     assert a > b
 
 
+def test_index_and_identifier():
+
+    M = UnitSquareMesh(10, 10)
+    MH = MeshHierarchy(M, 1)
+
+    V = [FunctionSpace(m, 'DG', 0) for m in MH]
+
+    F = Function(V[0])
+    G = Function(V[1])
+
+    S = State(F, G)
+
+    assert S.identifier is None
+    assert S.index is None
+
+    EH = EnsembleHierarchy(V)
+
+    EH.AppendToEnsemble(S)
+
+    assert isinstance(S.identifier, int)
+    assert isinstance(S.index, tuple)
+    assert len(S.index) == 2
+
+
+def test_reassigning_state():
+
+    M = UnitSquareMesh(10, 10)
+    MH = MeshHierarchy(M, 1)
+
+    V = [FunctionSpace(m, 'DG', 0) for m in MH]
+
+    F = Function(V[0])
+    G = Function(V[1])
+
+    S = State(F, G)
+
+    EH = EnsembleHierarchy(V)
+
+    EH.AppendToEnsemble(S)
+
+    S.state[0].assign(1.0)
+    S.state[1].assign(1.0)
+
+    assert isinstance(S.identifier, int)
+    assert isinstance(S.index, tuple)
+
+    assert np.max(np.abs(S.state[0].dat.data - 1.0)) < 1e-5
+    assert np.max(np.abs(S.state[1].dat.data - 1.0)) < 1e-5
+
+
 if __name__ == "__main__":
     import os
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Additions:

- Being able to update `State`s inside `EnsembleHierarchy`, and making a hierarchy (part of `EnsembleHierarchy`) that keeps `State`s existing on the original `FunctionSpace`s as to 'pick-up' with a realisation after calculating statistics etc.
- For the class to realise where a `State` is in an `EnsembleHierarchy` and as to replace/update it, index tuples are used, attributed to the `State` object.
- Unique idenitifiers are used to make sure that a `State` to be updated is definitely in an `EnsembleHierarchy` already and in the place that the index tells it to.