### PR TITLE
Estimator Variance Attr

### DIFF
--- a/examples/demo_ensemble_hierarchy.py
+++ b/examples/demo_ensemble_hierarchy.py
@@ -67,6 +67,9 @@ print 'With variance in cell basis coeffs on first level: ', e_h.Variance[0].dat
 
 print 'but none on the second: ', e_h.Variance[1].dat.data
 
+print ('And thus the multilevel Monte Carlo approximation variance is the first level sample ' +
+       'divided by the number of samples on that level: ', e_h.MultilevelVariance.dat.data)
+
 # now clear the ensemble
 e_h.UpdateStatistics(clear_ensemble=True)
 

--- a/firedrake_mlmc/ensemble_hierarchy.py
+++ b/firedrake_mlmc/ensemble_hierarchy.py
@@ -371,7 +371,7 @@ class EnsembleHierarchy(object):
 
         if self._type == Constant:
             mlmc_sum = Constant(0, domain=self._fs_hierarchy[-1].mesh())
-            mlmc_var = Function(self._fs_hierarchy[-1])
+            mlmc_var = Constant(0, domain=self._fs_hierarchy[-1].mesh())
 
         for i in range(self.L):
             mlmc_sum = mlmc_sum + self.Mean[i]

--- a/firedrake_mlmc/ensemble_hierarchy.py
+++ b/firedrake_mlmc/ensemble_hierarchy.py
@@ -69,10 +69,13 @@ class EnsembleHierarchy(object):
         # sample statistics
         if self._type == Function:
             self.MultilevelExpectation = Function(self._fs_hierarchy[-1])
+            self.MultilevelVariance = Function(self._fs_hierarchy[-1])
             self.MultilevelExpectation.rename('MLMC Estimator')
+            self.MultilevelVariance.rename('MLMC Variance')
 
         if self._type == Constant:
             self.MultilevelExpectation = Constant(0, domain=self._fs_hierarchy[-1].mesh())
+            self.MultilevelVariance = Constant(0, domain=self._fs_hierarchy[-1].mesh())
 
         self.Mean = []  # : A list of the sample mean Functions of each of the different levels
         self.Variance = []  # : A list of the sample variance Functions of each of the different levels
@@ -364,14 +367,18 @@ class EnsembleHierarchy(object):
         # update running multilevel monte carlo average
         if self._type == Function:
             mlmc_sum = Function(self._fs_hierarchy[-1])
+            mlmc_var = Function(self._fs_hierarchy[-1])
 
         if self._type == Constant:
             mlmc_sum = Constant(0, domain=self._fs_hierarchy[-1].mesh())
+            mlmc_var = Function(self._fs_hierarchy[-1])
 
         for i in range(self.L):
             mlmc_sum = mlmc_sum + self.Mean[i]
+            mlmc_var = mlmc_var + (self.Variance[i] / self.nl[i])
 
         self.MultilevelExpectation.assign(mlmc_sum)
+        self.MultilevelVariance.assign(mlmc_var)
 
         if clear_ensemble is True:
 

--- a/tests/test_ensemble_hierarchy.py
+++ b/tests/test_ensemble_hierarchy.py
@@ -341,6 +341,8 @@ def test_variance():
 
     EH.UpdateStatistics()
 
+    assert np.all(EH.MultilevelVariance.dat.data == 0) == 1
+
     assert np.all(EH.Variance[0].dat.data == 0) == 1
 
     assert np.all(EH.Variance[1].dat.data == 0) == 1


### PR DESCRIPTION
Alterations:

- Added an attribute that returns the mlmc estimator variance, of an `EnsembleHierarchy`. This is just the sum of difference estimator sample variances divided by the number of samples in each estimator.

- Added a line to an existing automated test that checks this.

- Added a line that prints this to an existing demo.